### PR TITLE
Add run.py as an easy way to start the snake.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This AI client uses the [bottle web framework](http://bottlepy.org/docs/dev/inde
 4. Run local server:
 
     ```shell
-    python app/main.py
+    python run.py
     ```
 
 5. Test your snake by sending a curl to the running snake

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,10 @@
+from __future__ import absolute_import
 import json
 import os
 import random
 import bottle
 
-from api import ping_response, start_response, move_response, end_response
+from .api import ping_response, start_response, move_response, end_response
 
 
 @bottle.route('/')
@@ -82,10 +83,13 @@ def end():
 # Expose WSGI app (so gunicorn can find it)
 application = bottle.default_app()
 
-if __name__ == '__main__':
+def main():
     bottle.run(
         application,
         host=os.getenv('IP', '0.0.0.0'),
         port=os.getenv('PORT', '8080'),
         debug=os.getenv('DEBUG', True)
     )
+
+if __name__ == '__main__':
+    main()

--- a/run.py
+++ b/run.py
@@ -1,0 +1,4 @@
+from app import main
+
+if __name__ == '__main__':
+    main.main()


### PR DESCRIPTION
This is a separate PR because it is not directly part of the upgrade to python 3, but my next pull request requires it. It changes how to start the snake from
python app/main.py
to
python run.py
The old way works in python 2, but because of the new python 3 way of specifying relative paths, the old call no longer works both locally and heroku.
Documentation is updated in the readme, and also matches the python tutorial PR I submitted.