### PR TITLE
Swtich gunicorn to cherrypy & upated to Python 3.8.1.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app.server --worker-class gevent
+web: python -m app.server

--- a/app/server.py
+++ b/app/server.py
@@ -4,6 +4,7 @@ import random
 
 import bottle
 from bottle import HTTPResponse
+from cheroot import wsgi
 
 
 @bottle.route("/")
@@ -72,17 +73,23 @@ def end():
     return HTTPResponse(status=200)
 
 
+class CherryPyServer(bottle.ServerAdapter):
+    def run(self, handler):
+        server = wsgi.Server((self.host, self.port), handler)
+        try:
+            server.start()
+        finally:
+            server.stop()
+
+
 def main():
     bottle.run(
-        application,
+        bottle.default_app(),
         host=os.getenv("IP", "0.0.0.0"),
         port=os.getenv("PORT", "8080"),
         debug=os.getenv("DEBUG", True),
+        server=CherryPyServer
     )
-
-
-# Expose WSGI app (so gunicorn can find it)
-application = bottle.default_app()
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 bottle==0.12.18
-gevent==1.4.0
-greenlet==0.4.15
-gunicorn==20.0.4
+cheroot==8.3.0

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.6
+python-3.8.1


### PR DESCRIPTION
Second attempt at a pull request for using cheroot/cherrypy. Here's why:
-This implementation uses cherrypy as the web framework both locally and on heroku, so the performance is good both locally and remotely
-cherrypy mostly outperforms gunicorn. See https://www.appdynamics.com/blog/engineering/a-performance-analysis-of-python-wsgi-servers-part-2/
-cherrypy only requires cheroot in the requirements.txt file
-cherrypy supports python 3.8.1