### PR TITLE
Removes the app.json, no-longer used

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,9 +1,0 @@
-{
-  "name": "Python Starter Snake",
-  "description": "A simple Battlesnake written in Python.",
-  "repository": "https://github.com/BattlesnakeOfficial/starter-snake-python",
-  "website": "https://play.battlesnake.com",
-  "keywords": [
-    "battlesnake"
-  ]
-}


### PR DESCRIPTION
The app.json was used for the Deploy to Heroku button in the README, but that no-longer exists.